### PR TITLE
Bump glpk to 4.52

### DIFF
--- a/glpk.rb
+++ b/glpk.rb
@@ -2,9 +2,9 @@ require 'formula'
 
 class Glpk < Formula
   homepage 'http://www.gnu.org/software/glpk/'
-  url 'http://ftpmirror.gnu.org/glpk/glpk-4.48.tar.gz'
-  mirror 'http://ftp.gnu.org/gnu/glpk/glpk-4.48.tar.gz'
-  sha1 'e00c92faa38fd5d865fa27206abbb06680bab7bb'
+  url 'http://ftpmirror.gnu.org/glpk/glpk-4.52.tar.gz'
+  mirror 'http://ftp.gnu.org/gnu/glpk/glpk-4.52.tar.gz'
+  sha1 '44b30b0de777a0a07e00615ac6791af180ff4d2c'
 
   bottle do
     root_url 'http://archive.org/download/julialang/bottles'


### PR DESCRIPTION
I just bumped the GLPK library version used in the GLPK.jl package; this should update the Homebrew bottle too (I hope - I don't know anything about homebrew and can't test).
