### PR TITLE
Optimization services for 10.9 and 10.10

### DIFF
--- a/bonmin.rb
+++ b/bonmin.rb
@@ -12,6 +12,9 @@ class Bonmin < Formula
   bottle do
     cellar :any
     root_url 'https://juliabottles.s3.amazonaws.com'
+    revision 1
+    sha256 "d32e4898dde9618446a18878df406d48982095d2433c715eda76d41a8a549a38" => :mavericks
+    sha256 "7b01c27e2c45f4944dd6f3ce7492e29247c9443bb730a51ecb9a79b6c12a657b" => :yosemite
   end
 
   def install

--- a/bonmin.rb
+++ b/bonmin.rb
@@ -12,9 +12,6 @@ class Bonmin < Formula
   bottle do
     cellar :any
     root_url 'https://juliabottles.s3.amazonaws.com'
-    sha1 "77dee65e7feff6c97af92677ccb404e1175fd16a" => :yosemite
-    sha1 "d5a08710ede17f3d2ca57f82d77d3b4bbf6ffd29" => :mavericks
-    sha1 "4a3dd43a64be65a8bf128f14cce6c780e9dc6e36" => :mountain_lion
   end
 
   def install

--- a/couenne.rb
+++ b/couenne.rb
@@ -1,0 +1,18 @@
+require 'formula'
+
+class Couenne < Formula
+  homepage 'https://projects.coin-or.org/Couenne'
+  url 'http://www.coin-or.org/download/pkgsource/Couenne/Couenne-0.5.2.tgz'
+  sha1 'c9dc1e4a75cc7cf02c78a33a79a385976e50b829'
+
+  depends_on 'staticfloat/juliadeps/pkg-config' => :build
+  depends_on 'staticfloat/juliadeps/bonmin'
+
+  def install
+    system "./configure", "--prefix=#{prefix}"
+    system "make"
+    system "make test"
+    ENV.deparallelize  # make install fails in parallel.
+    system "make install"
+  end
+end

--- a/couenne.rb
+++ b/couenne.rb
@@ -8,14 +8,6 @@ class Couenne < Formula
   depends_on 'staticfloat/juliadeps/pkg-config' => :build
   depends_on 'staticfloat/juliadeps/bonmin'
 
-  bottle do
-    root_url 'https://juliabottles.s3.amazonaws.com'
-    cellar :any
-    sha256 "d4a064bfd4f2af23857c393758bd28e249e94002755fc56df26aa57d438e2d82" => :mountain_lion
-    sha256 "6acf6cf47f906b732bd12bf6e87abbf82b63bccd2bb0cb74100d34a33bc4335f" => :mavericks
-    sha256 "5b0ed2272aae57d13558b73be2358d807c2bd2a8c6e005f1998a466b3e8dd204" => :yosemite
-  end
-
   def install
     system "./configure", "--prefix=#{prefix}"
     system "make"

--- a/couenne.rb
+++ b/couenne.rb
@@ -8,6 +8,14 @@ class Couenne < Formula
   depends_on 'staticfloat/juliadeps/pkg-config' => :build
   depends_on 'staticfloat/juliadeps/bonmin'
 
+  bottle do
+    root_url 'https://juliabottles.s3.amazonaws.com'
+    cellar :any
+    sha256 "d70ed6d0f461ff8909474d8d93aab94932862d0c46e717762c7899a4b9264aaf" => :yosemite
+    sha256 "4c381369a3e82fdbbb040873def8428db4c6ef22b4d5db4622d40da16f03ea8e" => :mavericks
+    sha256 "ac48f627ef6e57b9fa2479ffb1ecb2d64cdc9597abf7f6ef4f4f52a8f87178a9" => :mountain_lion
+  end
+
   def install
     system "./configure", "--prefix=#{prefix}"
     system "make"

--- a/couenne.rb
+++ b/couenne.rb
@@ -8,6 +8,14 @@ class Couenne < Formula
   depends_on 'staticfloat/juliadeps/pkg-config' => :build
   depends_on 'staticfloat/juliadeps/bonmin'
 
+  bottle do
+    root_url 'https://juliabottles.s3.amazonaws.com'
+    cellar :any
+    sha256 "d4a064bfd4f2af23857c393758bd28e249e94002755fc56df26aa57d438e2d82" => :mountain_lion
+    sha256 "6acf6cf47f906b732bd12bf6e87abbf82b63bccd2bb0cb74100d34a33bc4335f" => :mavericks
+    sha256 "5b0ed2272aae57d13558b73be2358d807c2bd2a8c6e005f1998a466b3e8dd204" => :yosemite
+  end
+
   def install
     system "./configure", "--prefix=#{prefix}"
     system "make"

--- a/couenne.rb
+++ b/couenne.rb
@@ -13,7 +13,6 @@ class Couenne < Formula
     cellar :any
     sha256 "d70ed6d0f461ff8909474d8d93aab94932862d0c46e717762c7899a4b9264aaf" => :yosemite
     sha256 "4c381369a3e82fdbbb040873def8428db4c6ef22b4d5db4622d40da16f03ea8e" => :mavericks
-    sha256 "ac48f627ef6e57b9fa2479ffb1ecb2d64cdc9597abf7f6ef4f4f52a8f87178a9" => :mountain_lion
   end
 
   def install

--- a/optimizationservices.rb
+++ b/optimizationservices.rb
@@ -1,0 +1,19 @@
+require 'formula'
+
+class Optimizationservices < Formula
+  homepage 'https://projects.coin-or.org/OS'
+  url 'http://www.coin-or.org/download/pkgsource/OS/OS-2.9.1.tgz'
+  sha1 'fd7bd169fb3925436f7a7ebdbf676a20b79140f0'
+
+  depends_on 'staticfloat/juliadeps/pkg-config' => :build
+  depends_on 'staticfloat/juliadeps/couenne'
+  depends_on 'homebrew/science/cppad' => :build
+
+  def install
+    system "./configure", "--prefix=#{prefix}"
+    system "make"
+    system "make -C test alltests"
+    ENV.deparallelize  # make install fails in parallel.
+    system "make install"
+  end
+end

--- a/optimizationservices.rb
+++ b/optimizationservices.rb
@@ -9,6 +9,13 @@ class Optimizationservices < Formula
   depends_on 'staticfloat/juliadeps/couenne'
   depends_on 'homebrew/science/cppad' => :build
 
+  bottle do
+    root_url 'https://juliabottles.s3.amazonaws.com'
+    cellar :any
+    sha256 "3f886b86b9a70377595621838d658155806648df14fc2e3442ce8695793b866e" => :mavericks
+    sha256 "6b93fda9d6fb0770bac1031b52f16e823e27222d492071ef3a06a151f174acfb" => :yosemite
+  end
+
   def install
     system "./configure", "--prefix=#{prefix}"
     system "make"


### PR DESCRIPTION
I'm tired of trying to figure out what is wrong with `bonmin` on 10.8, so I'm just going to release bottles for 10.9 and 10.10 for now.