### PR TITLE
Add Chemharp formula

### DIFF
--- a/chemharp.rb
+++ b/chemharp.rb
@@ -1,0 +1,32 @@
+class Chemharp < Formula
+    desc "Chemharp, an efficient IO library for chemistry file formats"
+    homepage "http://chemharp.readthedocs.org/"
+    url "https://github.com/Luthaf/Chemharp/archive/0.2.1.tar.gz"
+    sha256 "965223a94a5f0c0c22f4af1ad75b349fb2cc8e7868af74be4df71e17eaf981f2"
+
+    head "https://github.com/Luthaf/Chemharp.git"
+
+    depends_on "cmake" => :build
+    depends_on "homebrew/science/netcdf" => :optional
+    depends_on "boost"
+
+    option "with-python", "Build python bindings"
+    if build.with? "python-bindings"
+        depends_on "boost-python"
+    end
+
+    option "with-fortran", "Build Fortran bindings"
+    depends_on :fortran => :optional
+
+    def install
+        cmake_args = std_cmake_args
+        if build.with? "python"
+            cmake_args << "-DPYTHON_BINDING=ON"
+        end
+        if build.with? "fortran"
+            cmake_args << "-DFORTRAN_BINDING=ON"
+        end
+        system "cmake", ".", *cmake_args
+        system "make", "install"
+    end
+end


### PR DESCRIPTION
This will allow me to use Hombrew as a binary provider for the [Julia binding](https://github.com/Luthaf/Chemharp.jl/) to my [Chemharp](https://github.com/Luthaf/Chemharp/) library.

This is my first formula, and I am open to any comment !

In particular, I get this warning when I build the fortran binding (with gfortran), any idea on own to remove it ?
```
Warning: luthaf/juliadeps/chemharp dependency gcc was built with a different C++ standard
library (libstdc++ from clang). This may cause problems at runtime.
```