### PR TITLE
Missing root_url for chemharp bottles

### DIFF
--- a/chemharp.rb
+++ b/chemharp.rb
@@ -11,6 +11,7 @@ class Chemharp < Formula
     depends_on "boost"
 
     bottle do
+        root_url 'https://juliabottles.s3.amazonaws.com'
         cellar :any
         sha256 "24c50f49152271d1798b3e6c4c0d69d2df8ebb8d35d8da1fd7504b15f85642de" => :mavericks
         sha256 "31325c38e458b45aed245f628b0cf67a6bd55407643c39cf31c788b1c9a660c6" => :yosemite


### PR DESCRIPTION
This make the installation from bottle fails, as it search to download from `https://homebrew.bintray.com/`, and fallback to the source installation.