### PR TITLE
add DCTRLC flag to SCS

### DIFF
--- a/scs.rb
+++ b/scs.rb
@@ -17,7 +17,7 @@ class Scs < Formula
 
   def install
     # Make 32-bit build
-    ENV['CFLAGS'] = "-DDLONG -DCOPYAMATRIX -DLAPACK_LIB_FOUND"
+    ENV['CFLAGS'] = "-DDLONG -DCOPYAMATRIX -DLAPACK_LIB_FOUND -DCTRLC"
     ENV['LDFLAGS'] = "-undefined suppress -flat_namespace"
     system "make out/libscsdir.dylib"
     lib.install "out/libscsdir.dylib"


### PR DESCRIPTION
One of the tests is failing in SCS.jl: https://travis-ci.org/JuliaOpt/SCS.jl/jobs/68483766 (but all the others are passing strangely) and the reason is it can't find a method related to the CTRL-C interrupt functionality.

I'm not entirely sure how it managed to compile and how everything else worked, I can't reproduce the error locally when I compile the library myself, but this change should hopefully make sure it doesn't happen again (and gives CTRL-C interrupt functionality to SCS). I'm also going to make a change to SCS to hopefully prevent this there too.

If this looks good then we'll need to build the OSX binary again, so that the SDS.jl tests pass again.