### PR TITLE
Update pixman.rb to fix `mmx`-related error in El Capitan

### DIFF
--- a/pixman.rb
+++ b/pixman.rb
@@ -35,6 +35,7 @@ class Pixman < Formula
     system "./configure", "--disable-dependency-tracking",
                           "--disable-silent-rules",
                           "--prefix=#{prefix}",
+                          "--disable-mmx", # MMX assembler fails with Xcode 7 / osx El Capitan
                           "--disable-gtk"
     system "make", "install"
   end


### PR DESCRIPTION
The fix is already upstram on homebrew - reference commit: https://github.com/Homebrew/homebrew/commit/23a2c738a7286ea862daa86eee900585de17fb57