### PR TITLE
Fix fontconfig post_install

### DIFF
--- a/fontconfig.rb
+++ b/fontconfig.rb
@@ -43,7 +43,7 @@ class Fontconfig < Formula
 
   def post_install
     ohai "Regenerating font cache, this may take a while"
-    system "#{bin}/fc-cache", "-frv"
+    system "#{bin}/fc-cache -frv"
   end
 
   test do


### PR DESCRIPTION
Manually running `fc-cache -frv` in a julia shell works.

See https://github.com/JuliaPackaging/Homebrew.jl/issues/229 and https://github.com/JuliaPackaging/Homebrew.jl/issues/230 and https://github.com/staticfloat/homebrew-juliatranslated/issues/4

However, when using Homebrew.jl, the post_install fails and I believe that it is because somehow the `system` command here introduces a newline before the argument (see log in https://github.com/JuliaPackaging/Homebrew.jl/issues/229 – `-frv` appears on a new line).

This is a tentative to pass the `-frv` argument to `fc-cache`.

When opening an issue, please ping `@staticfloat`.

He does not receive emails automatically when new issues are created.
Without this ping, your issue may slip through the cracks!
If no response is garnered within a week, feel free to ping again.