### PR TITLE
Update from fontconfig 2.12 to 2.13

### DIFF
--- a/fontconfig.rb
+++ b/fontconfig.rb
@@ -1,8 +1,8 @@
 class Fontconfig < Formula
   desc "XML-based font configuration API for X Windows"
   homepage "https://wiki.freedesktop.org/www/Software/fontconfig/"
-  url "https://www.freedesktop.org/software/fontconfig/release/fontconfig-2.12.6.tar.bz2"
-  sha256 "cf0c30807d08f6a28ab46c61b8dbd55c97d2f292cf88f3a07d3384687f31f017"
+  url "https://www.freedesktop.org/software/fontconfig/release/fontconfig-2.13.0.tar.bz2"
+  sha256 "91dde8492155b7f34bb95079e79be92f1df353fcc682c19be90762fd3e12eeb9"
 
   bottle do
     root_url "https://homebrew.bintray.com/bottles"

--- a/fontconfig.rb
+++ b/fontconfig.rb
@@ -5,7 +5,6 @@ class Fontconfig < Formula
   sha256 "91dde8492155b7f34bb95079e79be92f1df353fcc682c19be90762fd3e12eeb9"
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles"
     cellar :any
     sha256 "66ad096a51d6253be02b4d3df0299d422c8bd1bccf571ed64a8b8b21a2e77bc7" => :high_sierra
     sha256 "d822bc26c6b556606087e5807293492814fedf9d408c857006b0886608010400" => :sierra

--- a/fontconfig.rb
+++ b/fontconfig.rb
@@ -5,6 +5,7 @@ class Fontconfig < Formula
   sha256 "91dde8492155b7f34bb95079e79be92f1df353fcc682c19be90762fd3e12eeb9"
 
   bottle do
+    root_url "https://homebrew.bintray.com/bottles"
     cellar :any
     sha256 "66ad096a51d6253be02b4d3df0299d422c8bd1bccf571ed64a8b8b21a2e77bc7" => :high_sierra
     sha256 "d822bc26c6b556606087e5807293492814fedf9d408c857006b0886608010400" => :sierra

--- a/fontconfig.rb
+++ b/fontconfig.rb
@@ -7,9 +7,9 @@ class Fontconfig < Formula
   bottle do
     root_url "https://homebrew.bintray.com/bottles"
     cellar :any
-    sha256 "8c9ff65654be03a4003d0e0d9e27fa1f03641aceadebd0f2a1b2f66cc1c2b54a" => :high_sierra
-    sha256 "cfa65615f05fe6e0547be2738bed94d21f05491df2edf1e246da8a3669225e4d" => :sierra
-    sha256 "664c8faf84a8bd6e80ebd8ca175c8e0a4cb6087f867e208cea4d9f8cda643134" => :el_capitan
+    sha256 "66ad096a51d6253be02b4d3df0299d422c8bd1bccf571ed64a8b8b21a2e77bc7" => :high_sierra
+    sha256 "d822bc26c6b556606087e5807293492814fedf9d408c857006b0886608010400" => :sierra
+    sha256 "a8016f2aff75677bab388a0ab138b4528d787c44c337f6ee7236e0de4a1cb268" => :el_capitan
   end
 
   depends_on "pkg-config" => :build


### PR DESCRIPTION
Update Julia Homebrew.jl's `fontconfig` version to the latest version: `2.13.0`.

Cairo.jl is currently failing to build on mac (failure: https://travis-ci.org/JuliaGraphics/Cairo.jl/jobs/415954409) because it requires `fontconfig >= 2.13`. This homebrew Formula is forcing `2.12` to be installed instead, so pangocairo fails to build.

For more information, please see this thread:
https://github.com/JuliaGraphics/Cairo.jl/issues/230


In this PR, i just blindly bumped the `url` and `sha` to what I see in my `homebrew-core/Formula/fontconfig.rb`. But maybe there are other lines that need to change as well? Here are the complete contents of my `~/.julia/v0.6/Homebrew/deps/usr/Library/Taps/homebrew/homebrew-core/Formula/fontconfig.rb`, which i got via ``julia0.6> Homebrew.brew(`edit fontconfig`)``:

```ruby
class Fontconfig < Formula
  desc "XML-based font configuration API for X Windows"
  homepage "https://wiki.freedesktop.org/www/Software/fontconfig/"
  url "https://www.freedesktop.org/software/fontconfig/release/fontconfig-2.13.0.tar.bz2"
  sha256 "91dde8492155b7f34bb95079e79be92f1df353fcc682c19be90762fd3e12eeb9"

  # The bottle tooling is too lenient and thinks fontconfig
  # is relocatable, but it has hardcoded paths in the executables.
  bottle do
    sha256 "66ad096a51d6253be02b4d3df0299d422c8bd1bccf571ed64a8b8b21a2e77bc7" => :high_sierra
    sha256 "d822bc26c6b556606087e5807293492814fedf9d408c857006b0886608010400" => :sierra
    sha256 "a8016f2aff75677bab388a0ab138b4528d787c44c337f6ee7236e0de4a1cb268" => :el_capitan
  end

  pour_bottle? do
    reason "The bottle needs to be installed into /usr/local."
    # c.f. the identical hack in lua
    # https://github.com/Homebrew/homebrew/issues/47173
    satisfy { HOMEBREW_PREFIX.to_s == "/usr/local" }
  end

  head do
    url "https://anongit.freedesktop.org/git/fontconfig", :using => :git

    depends_on "autoconf" => :build
    depends_on "automake" => :build
    depends_on "libtool" => :build
  end

  depends_on "pkg-config" => :build
  depends_on "freetype"

  def install
    # Remove for > 2.13.0
    # Upstream issue from 6 Mar 2018 "2.13.0 erroneously requires libuuid on macOS"
    # See https://bugs.freedesktop.org/show_bug.cgi?id=105366
    ENV["UUID_CFLAGS"] = " "
    ENV["UUID_LIBS"] = " "

    # Remove for > 2.13.0
    # Same effect as upstream commit from 10 Mar 2018 "Add uuid to
    # Requires.private in .pc only when pkgconfig macro found it"
    inreplace "configure",
      'PKGCONFIG_REQUIRES_PRIVATELY="$PKGCONFIG_REQUIRES_PRIVATELY uuid"', ""

    font_dirs = %w[
      /System/Library/Fonts
      /Library/Fonts
      ~/Library/Fonts
    ]

    if MacOS.version >= :sierra
      font_dirs << Dir["/System/Library/Assets/com_apple_MobileAsset_Font*"].max
    end

    system "autoreconf", "-iv" if build.head?
    system "./configure", "--disable-dependency-tracking",
                          "--disable-silent-rules",
                          "--enable-static",
                          "--with-add-fonts=#{font_dirs.join(",")}",
                          "--prefix=#{prefix}",
                          "--localstatedir=#{var}",
                          "--sysconfdir=#{etc}"
    system "make", "install", "RUN_FC_CACHE_TEST=false"
  end

  def post_install
    ohai "Regenerating font cache, this may take a while"
    system "#{bin}/fc-cache", "-frv"
  end

  test do
    system "#{bin}/fc-list"
  end
end
```

-------------------

And actually, that said, is there any need for this separate file? Can we just use the default Homebrew-installed Ruby file?



--------------------------------

When opening an issue, please ping `@staticfloat`.

He does not receive emails automatically when new issues are created.
Without this ping, your issue may slip through the cracks!
If no response is garnered within a week, feel free to ping again.