### PR TITLE
Replace ARGV.build_bottle? with Homebrew.args.build_bottle

### DIFF
--- a/ipopt.rb
+++ b/ipopt.rb
@@ -22,7 +22,7 @@ class Ipopt < Formula
   end
 
   # Need to enable this when building the bottle, disable it when installing from bottles
-  depends_on "gcc" if ARGV.build_bottle?
+  depends_on "gcc" if Homebrew.args.build_bottle
   depends_on 'staticfloat/juliadeps/libgfortran'
 
   def install


### PR DESCRIPTION
Hi @staticfloat

`ARGV.build_bottle?` is deprecated

See https://github.com/JuliaPackaging/Homebrew.jl/issues/270

